### PR TITLE
Expose Battery_soc reserve, to enable Timed Export and Discharge

### DIFF
--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -29,6 +29,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             ACChargeLimitNumber(coordinator, config_entry),
+            ChargeMinimumNumber(coordinator, config_entry),
             InverterBatteryChargeLimitNumber(coordinator, config_entry),
             InverterBatteryDischargeLimitNumber(coordinator, config_entry),
         ]
@@ -99,6 +100,46 @@ class ACChargeLimitNumber(InverterBasicNumber):
             self.hass,
             self.coordinator,
             enable_charge_target,
+        )
+
+
+class ChargeMinimumNumber(InverterBasicNumber):
+    """Number to represent and control the minimum SOC Limit."""
+
+    def __init__(
+        self,
+        coordinator: GivEnergyUpdateCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the Minimum Limit number."""
+        super().__init__(
+            coordinator,
+            config_entry,
+            NumberEntityDescription(
+                key="battery_soc_reserve",
+                name="Battery Shallow Charge Limit",
+                icon=Icon.BATTERY_MINUS,
+                native_unit_of_measurement=PERCENTAGE,
+            ),
+        )
+
+        # Values correspond to SOC percentage
+        self._attr_native_min_value = 4
+        self._attr_native_max_value = 100
+
+        # A 5% step size makes the slider a bit nicer to use
+        # self._attr_native_step = 5
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+
+        def set_shallow_charge(client: GivEnergyClient) -> None:
+            client.set_shallow_charge(int(value))
+
+        await async_reliable_call(
+            self.hass,
+            self.coordinator,
+            set_shallow_charge,
         )
 
 

--- a/custom_components/givenergy_local/number.py
+++ b/custom_components/givenergy_local/number.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             ACChargeLimitNumber(coordinator, config_entry),
-            ChargeMinimumNumber(coordinator, config_entry),
+            BatterySoCReserveNumber(coordinator, config_entry),
             InverterBatteryChargeLimitNumber(coordinator, config_entry),
             InverterBatteryDischargeLimitNumber(coordinator, config_entry),
         ]
@@ -103,21 +103,21 @@ class ACChargeLimitNumber(InverterBasicNumber):
         )
 
 
-class ChargeMinimumNumber(InverterBasicNumber):
-    """Number to represent and control the minimum SOC Limit."""
+class BatterySoCReserveNumber(InverterBasicNumber):
+    """Number to represent and control the Battery SOC Reserve."""
 
     def __init__(
         self,
         coordinator: GivEnergyUpdateCoordinator,
         config_entry: ConfigEntry,
     ) -> None:
-        """Initialize the Minimum Limit number."""
+        """Initialize the Battery SOC Reserve number."""
         super().__init__(
             coordinator,
             config_entry,
             NumberEntityDescription(
                 key="battery_soc_reserve",
-                name="Battery Shallow Charge Limit",
+                name="Battery SOC Reserve",
                 icon=Icon.BATTERY_MINUS,
                 native_unit_of_measurement=PERCENTAGE,
             ),

--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -465,19 +465,19 @@ class BatteryModeSensor(InverterBasicSensor):
         # battery_power_mode:
         # 0: export/max
         # 1: demand/self-consumption
+        # enable_discharge:
+        # 0: Eco
+        # 1: Timed Discharge/Timed Export
         battery_power_mode = self.data.battery_power_mode
-        battery_soc_reserve = self.data.battery_soc_reserve
+        # battery_soc_reserve = self.data.battery_soc_reserve
         enable_discharge = self.data.enable_discharge
 
-        if battery_power_mode == 1 and battery_soc_reserve == 4:
-            return "Eco"
-
-        if enable_discharge is True and battery_soc_reserve == 100:
+        if enable_discharge is True:
             if battery_power_mode == 1:
                 return "Timed Discharge"
             else:
                 return "Timed Export"
-        return "Unknown"
+        return "Eco"
 
 
 class BatteryBasicSensor(BatteryEntity, SensorEntity):

--- a/custom_components/givenergy_local/services.py
+++ b/custom_components/givenergy_local/services.py
@@ -23,6 +23,7 @@ _ATTR_POWER = "power"
 _ATTR_START_TIME = "start_time"
 _ATTR_END_TIME = "end_time"
 _ATTR_CHARGE_TARGET = "charge_target"
+_ATTR_SHALLOW_CHARGE = "shallow_charge"
 
 # Shared schema used for setting charge/discharge power limits.
 _SET_POWER_SCHEMA = vol.Schema(
@@ -38,6 +39,9 @@ _TIME_SPAN_SCHEMA = vol.Schema(
         vol.Required(ATTR_DEVICE_ID): str,
         vol.Required(_ATTR_START_TIME): str,
         vol.Required(_ATTR_END_TIME): str,
+        vol.Required(_ATTR_SHALLOW_CHARGE): vol.All(
+            vol.Coerce(int), vol.Range(min=4, max=100)
+        ),
     }
 )
 
@@ -218,6 +222,7 @@ async def _async_activate_mode_timed_discharge(
             "Activating timed discharge mode between %s and %s", start_time, end_time
         )
         client.set_mode_storage((start_time, end_time), export=False)
+        client.set_shallow_charge(data[_ATTR_SHALLOW_CHARGE])
 
     await _async_service_call(hass, data[ATTR_DEVICE_ID], call)
 
@@ -235,6 +240,8 @@ async def _async_activate_mode_timed_export(
             "Activating timed export mode between %s and %s", start_time, end_time
         )
         client.set_mode_storage((start_time, end_time), export=True)
+
+        client.set_shallow_charge(data[_ATTR_SHALLOW_CHARGE])
 
     await _async_service_call(hass, data[ATTR_DEVICE_ID], call)
 

--- a/custom_components/givenergy_local/services.yaml
+++ b/custom_components/givenergy_local/services.yaml
@@ -67,8 +67,8 @@ activate_mode_eco:
 activate_mode_timed_discharge:
   name: Activate timed discharge mode
   description: >
-    This mode will is similar to Eco mode charge and discharge your batteries to minimise your import from the grid.
-    But it will discharge battery at full power during a period you define, until Charge Reserve is reached.
+    Outside of the timed period this mode will charge and discharge your batteries to minimise your import from the grid.
+    During the timed period it will discharge battery at full power. Discharge will stop if Battery SOC Reserve is reached.
   fields:
     device_id:
       name: Device
@@ -90,9 +90,9 @@ activate_mode_timed_discharge:
       selector:
         time:
     shallow_charge:
-      name: Shallow Charge
+      name: Battery SOC Reserve
       description: >
-        Battery SOC minimum during discharging.
+        Stop discharging at or below this limit
       required: true
       selector:
         number:
@@ -102,8 +102,8 @@ activate_mode_timed_discharge:
 activate_mode_timed_export:
   name: Activate timed export mode
   description: >
-    This mode will hold your battery power, trickle charging at ~300w only if battery is below Charge Reserve. It will send any excess PV to the grid.
-    It will discharge battery at full power during a period you define, until Charge Reserve is reached
+    Outside of the timed period this mode will send any excess PV to the grid, and NOT discharge the battery to meet demand.
+    During the timed period it will discharge battery at full power. Discharge will stop if Battery SOC Reserve is reached.
   fields:
     device_id:
       name: Device
@@ -125,9 +125,9 @@ activate_mode_timed_export:
       selector:
         time:
     shallow_charge:
-      name: Shallow Charge
+      name: Battery SOC Reserve
       description: >
-        Battery SOC minimum during discharging.
+        Stop discharging at or below this limit
       required: true
       selector:
         number:

--- a/custom_components/givenergy_local/services.yaml
+++ b/custom_components/givenergy_local/services.yaml
@@ -67,8 +67,8 @@ activate_mode_eco:
 activate_mode_timed_discharge:
   name: Activate timed discharge mode
   description: >
-    This mode will discharge your batteries to your home during a period you
-    define
+    This mode will is similar to Eco mode charge and discharge your batteries to minimise your import from the grid.
+    But it will discharge battery at full power during a period you define, until Charge Reserve is reached.
   fields:
     device_id:
       name: Device
@@ -89,11 +89,21 @@ activate_mode_timed_discharge:
       required: true
       selector:
         time:
+    shallow_charge:
+      name: Shallow Charge
+      description: >
+        Battery SOC minimum during discharging.
+      required: true
+      selector:
+        number:
+          min: 4
+          max: 100
+          unit_of_measurement: "%"
 activate_mode_timed_export:
   name: Activate timed export mode
   description: >
-    This mode will hold your battery power and discharge it at full power
-    during a period you define
+    This mode will hold your battery power, trickle charging at ~300w only if battery is below Charge Reserve. It will send any excess PV to the grid.
+    It will discharge battery at full power during a period you define, until Charge Reserve is reached
   fields:
     device_id:
       name: Device
@@ -114,6 +124,16 @@ activate_mode_timed_export:
       required: true
       selector:
         time:
+    shallow_charge:
+      name: Shallow Charge
+      description: >
+        Battery SOC minimum during discharging.
+      required: true
+      selector:
+        number:
+          min: 4
+          max: 100
+          unit_of_measurement: "%"
 enable_timed_charge:
   name: Enable timed charging
   description: >


### PR DESCRIPTION
Without setting battery_soc_reserve to less than 100, then on my inverter, the battery does not discharge in timed discharge or export. The givenergy-modbus  set_mode_storage sets a default set_shallow_charge = 100, which then sets battery_soc_reserve = 100.

These changes add battery soc reserve slider to timed discharge and timed export services, and expose set_shallow_charge as a number, and as a slider control.

These changes break the logic to determine battery mode, but if you ignore the soc value check, I think the logic still works.