### PR TITLE
bump pydantic to 1.10.15 for HA 2024.6 support

### DIFF
--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -14,7 +14,7 @@
     "aiofiles==0.8.0",
     "arrow==1.2.3",
     "crccheck==1.3.0",
-    "pydantic==1.10.12",
+    "pydantic==1.10.15",
     "aenum==3.1.12"
   ],
   "version": "0.0.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiofiles==0.8.0
 arrow==1.2.3
 crccheck==1.3.0
-pydantic==1.10.12
+pydantic==1.10.15
 aenum==3.1.12
 homeassistant


### PR DESCRIPTION
## Summary

Bumps pydantic to 1.10.15 (from 1.10.12) to enable support for Home Assistant 2024.6, which ships with .15 by default

## Testing

* Have tested this manually against HA 2024.6
  * All of the basic functions appear to work, such as reading values. I've not tested any user input or writes.
* [ ] TODO: Have NOT tested this against pre-2024.6