### PR TITLE
Compat with Pydantic v2 for ha2025

### DIFF
--- a/custom_components/givenergy_local/givenergy_modbus/model/__init__.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/__init__.py
@@ -7,7 +7,7 @@ from datetime import time
 from enum import IntEnum
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 if TYPE_CHECKING:
     from custom_components.givenergy_local.givenergy_modbus.model.register_cache import (

--- a/custom_components/givenergy_local/givenergy_modbus/model/__init__.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/__init__.py
@@ -7,7 +7,10 @@ from datetime import time
 from enum import IntEnum
 from typing import TYPE_CHECKING
 
-from pydantic.v1 import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from custom_components.givenergy_local.givenergy_modbus.model.register_cache import (

--- a/custom_components/givenergy_local/givenergy_modbus/model/battery.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/battery.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 
-from pydantic import BaseConfig, create_model
+from pydantic.v1 import BaseConfig, create_model
 
 from custom_components.givenergy_local.givenergy_modbus.model.register import IR
 from custom_components.givenergy_local.givenergy_modbus.model.register import (

--- a/custom_components/givenergy_local/givenergy_modbus/model/battery.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/battery.py
@@ -1,6 +1,9 @@
 from enum import IntEnum
 
-from pydantic.v1 import BaseConfig, create_model
+try:
+    from pydantic.v1 import BaseConfig, create_model
+except ImportError:
+    from pydantic import BaseConfig, create_model
 
 from custom_components.givenergy_local.givenergy_modbus.model.register import IR
 from custom_components.givenergy_local.givenergy_modbus.model.register import (

--- a/custom_components/givenergy_local/givenergy_modbus/model/inverter.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/inverter.py
@@ -1,7 +1,7 @@
 from enum import IntEnum, StrEnum
 import math
 
-from pydantic import BaseConfig, create_model
+from pydantic.v1 import BaseConfig, create_model
 
 from custom_components.givenergy_local.givenergy_modbus.model.register import HR, IR
 from custom_components.givenergy_local.givenergy_modbus.model.register import (

--- a/custom_components/givenergy_local/givenergy_modbus/model/inverter.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/inverter.py
@@ -1,7 +1,10 @@
 from enum import IntEnum, StrEnum
 import math
 
-from pydantic.v1 import BaseConfig, create_model
+try:
+    from pydantic.v1 import BaseConfig, create_model
+except ImportError:
+    from pydantic import BaseConfig, create_model
 
 from custom_components.givenergy_local.givenergy_modbus.model.register import HR, IR
 from custom_components.givenergy_local.givenergy_modbus.model.register import (

--- a/custom_components/givenergy_local/givenergy_modbus/model/register.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/register.py
@@ -4,7 +4,10 @@ from json import JSONEncoder
 import math
 from typing import Any, Callable, Optional, Union
 
-from pydantic.v1.utils import GetterDict
+try:
+    from pydantic.v1.utils import GetterDict
+except ImportError:
+    from pydantic.utils import GetterDict
 from custom_components.givenergy_local.givenergy_modbus.exceptions import (
     ConversionError,
 )

--- a/custom_components/givenergy_local/givenergy_modbus/model/register.py
+++ b/custom_components/givenergy_local/givenergy_modbus/model/register.py
@@ -4,7 +4,7 @@ from json import JSONEncoder
 import math
 from typing import Any, Callable, Optional, Union
 
-from pydantic.utils import GetterDict
+from pydantic.v1.utils import GetterDict
 from custom_components.givenergy_local.givenergy_modbus.exceptions import (
     ConversionError,
 )

--- a/custom_components/givenergy_local/manifest.json
+++ b/custom_components/givenergy_local/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/cdpuk/givenergy-local/issues",
   "requirements": [
     "crccheck~=1.3",
-    "pydantic>=1.10.12,<2"
+    "pydantic"
   ],
   "version": "0.0.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 crccheck~=1.3
 
-# HA 2023.10 was pinned to 1.10.12
-# pydantic v2 is known to have breaking changes
-pydantic>=1.10.12,<2
+pydantic
 
 # Don't pin the HA version
 homeassistant


### PR DESCRIPTION
This is a quick code patch to use the shims in pydantic 2+ that's being used in homeassistant 2025.1

Fixes #108 

I've added `try/except ImportError` shims to keep it backwards compatible with 2024.