### PR TITLE
Add missing state class

### DIFF
--- a/custom_components/givenergy_local/sensor.py
+++ b/custom_components/givenergy_local/sensor.py
@@ -187,6 +187,7 @@ _BASIC_INVERTER_SENSORS = [
     SensorEntityDescription(
         key="battery_percent",
         name="Battery Percent",
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
     ),


### PR DESCRIPTION
Without this, on newer versions of home assistant, the history graph is fragmented, rather than continuous (see image)

<img width="1688" height="776" alt="image" src="https://github.com/user-attachments/assets/038b97c1-ef7c-482b-9c40-c90c78599e74" />
