### PR TITLE
fix: Use timezone-aware datetime in sync_clock service

### DIFF
--- a/custom_components/givenergy_local/services.py
+++ b/custom_components/givenergy_local/services.py
@@ -7,6 +7,7 @@ from typing import Any
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
+from homeassistant.util import dt as dt_util
 import voluptuous as vol
 
 from custom_components.givenergy_local.givenergy_modbus.pdu.transparent import (
@@ -231,5 +232,5 @@ async def _async_sync_clock(hass: HomeAssistant, data: dict[str, Any]) -> None:
     await _async_service_call(
         hass,
         data[ATTR_DEVICE_ID],
-        CommandBuilder.set_system_date_time(datetime.datetime.now()),
+        CommandBuilder.set_system_date_time(dt_util.now()),
     )


### PR DESCRIPTION
## Summary

The `sync_clock` service uses `datetime.datetime.now()`, which returns a naive datetime based on the system's local time. This means the inverter clock gets set incorrectly for any user whose Home Assistant configured timezone differs from the host OS timezone (e.g. running HA in a container where the system clock is UTC).

This replaces it with `homeassistant.util.dt.now()`, which returns a timezone-aware datetime using the user's configured HA timezone — consistent with how all other HA integrations handle local time.

## Changes

- Import `homeassistant.util.dt`
- Replace `datetime.datetime.now()` with `dt_util.now()` in `_async_sync_clock`

## Test plan

- Verify `sync_clock` service sets the inverter clock to the correct local time when HA timezone differs from the host OS timezone